### PR TITLE
テキストが折り返されない問題の解決

### DIFF
--- a/web_article/article/templates/article_detail.html
+++ b/web_article/article/templates/article_detail.html
@@ -13,9 +13,8 @@
             </div>
         </div>
         <hr>
-
         <div class="row">
-            <div class="col-lg-8">
+            <div class="col-lg-8" style="word-wrap: break-word">
                 {{ object.content|linebreaksbr }}
             </div>
             <div class="col-lg-4">


### PR DESCRIPTION
折り返したい文章に対して`word-wrap: break-word;`をつけてあげれば治った
参考: https://stackoverflow.com/questions/23641913/bootstrap-3-wrap-text-content-within-div-for-horizontal-alignment

ただ、本来bootstrapのgrid systemはcssを追加しなくても文書を折り返してくれるはずなのにcssを追加しないと折り返されないのは普通に謎
https://getbootstrap.com/docs/4.1/layout/grid/#column-wrapping
これとかは何もしなくても文書が折り返されている
もしかしたら、Grid Systemの設定がどこかで間違ってるかもしれないから、時間があったら見てみて。
